### PR TITLE
Enable redirects for inactive or non-found subdomains to full URLs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name":"pronique/multitenant",
+	"name":"pdata/multitenant",
 	"version": "0.8.1",
 	"description":"MultiTenant CakePHP Plugin -  Use this plugin to easily build SaaS enabled web applications.",
 	"type":"cakephp-plugin",
@@ -16,7 +16,7 @@
 		"cake",
 		"pronique"
 	],
-	"homepage":"https://github.com/pronique/multitenant",
+	"homepage":"https://github.com/pdata/multitenant",
 	"license":"MIT",
 	"authors":[
 		{

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name":"pdata/multitenant",
+	"name":"pronique/multitenant",
 	"version": "0.8.1",
 	"description":"MultiTenant CakePHP Plugin -  Use this plugin to easily build SaaS enabled web applications.",
 	"type":"cakephp-plugin",
@@ -16,7 +16,7 @@
 		"cake",
 		"pronique"
 	],
-	"homepage":"https://github.com/pdata/multitenant",
+	"homepage":"https://github.com/pronique/multitenant",
 	"license":"MIT",
 	"authors":[
 		{


### PR DESCRIPTION
Proposed change to enable redirects for inactive or non-found subdomains to full URLs in addition to the existing functionality to redirect to the primary domain. At EventHQ (an other SaaS apps) we use a specific subdomain, get.eventhq.co.uk to handle new account creation as our marketing website (www.eventhq.co.uk) is a completely separate entity to the actual application.