### PR TITLE
Class Not Found Error in config/bootstrap.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,5 +17,3 @@ namespace MultiTenant\Config;
 use MultiTenant\Core\MTApp;
 use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\Configure;
-
-MTApp::config(Configure::consume('MultiTenant'));


### PR DESCRIPTION
Removing the following line:

`MTApp::config(Configure::consume('MultiTenant'));`

Resolves this issue, though I'll be honest here I'm very new to CakePHP so I'm unsure of what other affects it may have. The full error is referenced in issue #13 and this appears to be the culprit. Removal of that line returns the application to working order. 

Please let me know if you have any questions/feedback/input. Thanks. 
